### PR TITLE
chore: upgrade Django from 4.2.20 to 4.2.25

### DIFF
--- a/edx_ace/__init__.py
+++ b/edx_ace/__init__.py
@@ -13,7 +13,7 @@ from .policy import Policy, PolicyResult
 from .recipient import Recipient
 from .recipient_resolver import RecipientResolver
 
-__version__ = '1.15.0'
+__version__ = '1.15.1'
 
 
 __all__ = [

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this application
 
 -c constraints.txt
-Django>=2.2                       # Web application framework
+Django==4.2.25                       # Web application framework
 python-dateutil                   # Python Date Utilities
 attrs>=17.2.0                     # Attributes without boilerplate
 sailthru-client==2.2.3

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,31 +4,31 @@
 #
 #    make upgrade
 #
-cachetools==5.5.2
+cachetools==7.0.1
     # via tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-filelock==3.18.0
+filelock==3.21.2
     # via
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.7
+platformdirs==4.7.1
     # via
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via tox
-pyproject-api==1.9.0
+pyproject-api==1.10.0
     # via tox
-tox==4.25.0
+tox==4.35.0
     # via -r requirements/ci.in
-virtualenv==20.30.0
+virtualenv==20.36.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -165,7 +165,7 @@ jinja2==3.1.6
     #   diff-cover
 keyring==25.7.0
     # via twine
-lxml[html-clean]==6.0.2
+lxml==6.0.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,25 +4,28 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+anyio==4.12.1
+    # via httpx
+asgiref==3.11.1
     # via django
-astroid==3.3.9
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+attrs==25.4.0
     # via -r requirements/base.in
-build==1.2.2.post1
+build==1.4.0
     # via pip-tools
-cachecontrol==0.14.2
+cachecontrol==0.14.4
     # via firebase-admin
-cachetools==5.5.2
+cachetools==7.0.1
+    # via tox
+certifi==2026.1.4
     # via
-    #   google-auth
-    #   tox
-certifi==2025.1.31
-    # via requests
-cffi==1.17.1
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
@@ -30,9 +33,9 @@ chardet==5.2.0
     # via
     #   diff-cover
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via requests
-click==8.1.8
+click==8.3.1
     # via
     #   click-log
     #   code-annotations
@@ -45,15 +48,18 @@ code-annotations==2.3.0
     # via edx-lint
 colorama==0.4.6
     # via tox
-cryptography==44.0.2
-    # via pyjwt
-diff-cover==9.2.4
+cryptography==46.0.5
+    # via
+    #   google-auth
+    #   pyjwt
+    #   secretstorage
+diff-cover==10.2.0
     # via -r requirements/dev.in
-dill==0.4.0
+dill==0.4.1
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-django==4.2.20
+django==4.2.25
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -64,173 +70,178 @@ django==4.2.20
     #   edx-i18n-tools
 django-crum==0.7.9
     # via edx-django-utils
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via -r requirements/base.in
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via edx-django-utils
-docutils==0.21.2
+docutils==0.22.4
     # via readme-renderer
-edx-django-utils==7.4.0
+edx-django-utils==8.0.1
     # via -r requirements/base.in
-edx-i18n-tools==1.8.0
+edx-i18n-tools==1.9.0
     # via -r requirements/dev.in
 edx-lint==5.6.0
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
-filelock==3.18.0
+filelock==3.21.2
     # via
     #   tox
     #   virtualenv
-firebase-admin==6.8.0
+firebase-admin==7.1.0
     # via -r requirements/base.in
-google-api-core[grpc]==2.24.2
+google-api-core[grpc]==2.29.0
     # via
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.168.0
-    # via firebase-admin
-google-auth==2.39.0
+google-auth==2.48.0
     # via
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via google-api-python-client
-google-cloud-core==2.4.3
+google-cloud-core==2.5.0
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.20.2
+google-cloud-firestore==2.23.0
     # via firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.9.0
     # via firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.8.0
     # via google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.72.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.72.0
+grpcio==1.78.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.0
+grpcio-status==1.78.0
     # via google-api-core
-httplib2==0.22.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
-id==1.5.0
+h11==0.16.0
+    # via httpcore
+h2==4.3.0
+    # via httpx
+hpack==4.1.0
+    # via h2
+httpcore==1.0.9
+    # via httpx
+httpx[http2]==0.28.1
+    # via firebase-admin
+hyperframe==6.1.0
+    # via h2
+id==1.6.1
     # via twine
-idna==3.10
-    # via requests
-isort==6.0.1
+idna==3.11
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+isort==7.0.0
     # via
     #   -r requirements/quality.in
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.4.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via
     #   code-annotations
     #   diff-cover
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-lxml[html-clean,html_clean]==5.4.0
+lxml[html-clean]==6.0.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via lxml
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-msgpack==1.1.0
+msgpack==1.1.2
     # via cachecontrol
-newrelic==10.10.0
-    # via edx-django-utils
-nh3==0.2.21
+nh3==0.3.2
     # via readme-renderer
-packaging==25.0
+packaging==26.0
     # via
     #   build
     #   pyproject-api
     #   tox
     #   twine
+    #   wheel
 path==16.16.0
     # via edx-i18n-tools
-pbr==6.1.1
-    # via stevedore
-pip-tools==7.4.1
+pip-tools==7.5.3
     # via -r requirements/dev.in
-platformdirs==4.3.7
+platformdirs==4.7.1
     # via
     #   pylint
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   diff-cover
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-proto-plus==1.26.1
+proto-plus==1.27.1
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.30.2
+protobuf==6.33.5
     # via
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.0.0
+psutil==7.2.2
     # via edx-django-utils
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.in
-pycparser==2.22
+pycparser==3.0
     # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   diff-cover
     #   readme-renderer
     #   rich
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via firebase-admin
-pylint==3.3.6
+pylint==4.0.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -238,17 +249,15 @@ pylint==3.3.6
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pynacl==1.5.0
+pynacl==1.6.2
     # via edx-django-utils
-pyparsing==3.2.3
-    # via httplib2
-pyproject-api==1.9.0
+pyproject-api==1.10.0
     # via tox
 pyproject-hooks==1.2.0
     # via
@@ -258,18 +267,17 @@ python-dateutil==2.9.0.post0
     # via -r requirements/base.in
 python-slugify==8.0.4
     # via code-annotations
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   code-annotations
     #   edx-i18n-tools
 readme-renderer==44.0
     # via twine
-requests==2.32.3
+requests==2.32.5
     # via
     #   cachecontrol
     #   google-api-core
     #   google-cloud-storage
-    #   id
     #   requests-toolbelt
     #   sailthru-client
     #   twine
@@ -277,46 +285,50 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.3.2
     # via twine
 rsa==4.9.1
     # via google-auth
 sailthru-client==2.2.3
     # via -r requirements/base.in
-simplejson==3.20.1
+secretstorage==3.5.0
+    # via keyring
+simplejson==3.20.2
     # via sailthru-client
 six==1.17.0
     # via
     #   -r requirements/base.in
     #   edx-lint
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via pydocstyle
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/base.in
     #   code-annotations
     #   edx-django-utils
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.2
+tomlkit==0.14.0
     # via pylint
-tox==4.25.0
+tox==4.35.0
     # via -r requirements/dev.in
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/dev.in
-uritemplate==4.1.1
-    # via google-api-python-client
-urllib3==2.2.3
+typing-extensions==4.15.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   anyio
+    #   grpcio
+urllib3==2.6.3
+    # via
+    #   id
     #   requests
     #   twine
-virtualenv==20.30.0
+virtualenv==20.36.1
     # via tox
-wheel==0.45.1
+wheel==0.46.3
     # via
     #   -r requirements/dev.in
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,33 +8,39 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-asgiref==3.8.1
+anyio==4.12.1
+    # via httpx
+asgiref==3.11.1
     # via django
-attrs==25.3.0
+attrs==25.4.0
     # via -r requirements/base.in
-babel==2.17.0
+babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.4
+beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-cachecontrol==0.14.2
+cachecontrol==0.14.4
     # via firebase-admin
-cachetools==5.5.2
-    # via google-auth
-certifi==2025.1.31
-    # via requests
-cffi==1.17.1
+certifi==2026.1.4
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via requests
-click==8.1.8
+click==8.3.1
     # via edx-django-utils
-cryptography==44.0.2
-    # via pyjwt
-django==4.2.20
+cryptography==46.0.5
+    # via
+    #   google-auth
+    #   pyjwt
+    #   secretstorage
+django==4.2.25
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -44,11 +50,11 @@ django==4.2.20
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via -r requirements/base.in
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via edx-django-utils
-doc8==1.1.2
+doc8==2.0.0
     # via -r requirements/doc.in
 docutils==0.21.2
     # via
@@ -57,120 +63,124 @@ docutils==0.21.2
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-django-utils==7.4.0
+edx-django-utils==8.0.1
     # via -r requirements/base.in
-firebase-admin==6.8.0
+firebase-admin==7.1.0
     # via -r requirements/base.in
-google-api-core[grpc]==2.24.2
+google-api-core[grpc]==2.29.0
     # via
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.168.0
-    # via firebase-admin
-google-auth==2.39.0
+google-auth==2.48.0
     # via
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via google-api-python-client
-google-cloud-core==2.4.3
+google-cloud-core==2.5.0
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.20.2
+google-cloud-firestore==2.23.0
     # via firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.9.0
     # via firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.8.0
     # via google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.72.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.72.0
+grpcio==1.78.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.0
+grpcio-status==1.78.0
     # via google-api-core
-httplib2==0.22.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
-id==1.5.0
+h11==0.16.0
+    # via httpcore
+h2==4.3.0
+    # via httpx
+hpack==4.1.0
+    # via h2
+httpcore==1.0.9
+    # via httpx
+httpx[http2]==0.28.1
+    # via firebase-admin
+hyperframe==6.1.0
+    # via h2
+id==1.6.1
     # via twine
-idna==3.10
-    # via requests
+idna==3.11
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 imagesize==1.4.1
     # via sphinx
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.4.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via sphinx
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-msgpack==1.1.0
+msgpack==1.1.2
     # via cachecontrol
-newrelic==10.10.0
-    # via edx-django-utils
-nh3==0.2.21
+nh3==0.3.2
     # via readme-renderer
-packaging==25.0
+packaging==26.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
     #   twine
-pbr==6.1.1
-    # via stevedore
-proto-plus==1.26.1
+proto-plus==1.27.1
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.30.2
+protobuf==6.33.5
     # via
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.0.0
+psutil==7.2.2
     # via edx-django-utils
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==2.22
+pycparser==3.0
     # via cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   accessible-pygments
     #   doc8
@@ -178,53 +188,52 @@ pygments==2.19.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via firebase-admin
-pynacl==1.5.0
+pynacl==1.6.2
     # via edx-django-utils
-pyparsing==3.2.3
-    # via httplib2
 python-dateutil==2.9.0.post0
     # via -r requirements/base.in
 readme-renderer==44.0
     # via
     #   -r requirements/doc.in
     #   twine
-requests==2.32.3
+requests==2.32.5
     # via
     #   cachecontrol
     #   google-api-core
     #   google-cloud-storage
-    #   id
     #   requests-toolbelt
     #   sailthru-client
     #   sphinx
     #   twine
 requests-toolbelt==1.0.0
     # via twine
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.3.2
     # via twine
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 rsa==4.9.1
     # via google-auth
 sailthru-client==2.2.3
     # via -r requirements/base.in
-simplejson==3.20.1
+secretstorage==3.5.0
+    # via keyring
+simplejson==3.20.2
     # via sailthru-client
 six==1.17.0
     # via
     #   -r requirements/base.in
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.7
+soupsieve==2.8.3
     # via beautifulsoup4
-sphinx==8.2.3
+sphinx==9.1.0
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
@@ -243,26 +252,23 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/base.in
     #   doc8
     #   edx-django-utils
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/doc.in
-typing-extensions==4.13.2
+typing-extensions==4.15.0
     # via
+    #   anyio
     #   beautifulsoup4
+    #   grpcio
     #   pydata-sphinx-theme
-uritemplate==4.1.1
-    # via google-api-python-client
-urllib3==2.2.3
+urllib3==2.6.3
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   id
     #   requests
     #   twine
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,19 +4,21 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.4.0
     # via pip-tools
-click==8.1.8
+click==8.3.1
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.4.1
+packaging==26.0
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,15 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+packaging==26.0
+    # via wheel
+wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
+pip==25.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==79.0.1
+setuptools==82.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-astroid==3.3.9
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-click==8.1.8
+click==8.3.1
     # via
     #   click-log
     #   code-annotations
@@ -17,29 +17,27 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==2.3.0
     # via edx-lint
-dill==0.4.0
+dill==0.4.1
     # via pylint
 edx-lint==5.6.0
     # via -r requirements/quality.in
-isort==6.0.1
+isort==7.0.0
     # via
     #   -r requirements/quality.in
     #   pylint
 jinja2==3.1.6
     # via code-annotations
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-pbr==6.1.1
-    # via stevedore
-platformdirs==4.3.7
+platformdirs==4.7.1
     # via pylint
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==3.3.6
+pylint==4.0.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -47,26 +45,23 @@ pylint==3.3.6
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
 python-slugify==8.0.4
     # via code-annotations
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via code-annotations
 six==1.17.0
     # via edx-lint
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via pydocstyle
-stevedore==5.4.1
+stevedore==5.6.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.2
+tomlkit==0.14.0
     # via pylint
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,30 +4,33 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+anyio==4.12.1
+    # via httpx
+asgiref==3.11.1
     # via django
-attrs==25.3.0
-    # via
-    #   -r requirements/base.in
-    #   hypothesis
-cachecontrol==0.14.2
+attrs==25.4.0
+    # via -r requirements/base.in
+cachecontrol==0.14.4
     # via firebase-admin
-cachetools==5.5.2
-    # via google-auth
-certifi==2025.1.31
-    # via requests
-cffi==1.17.1
+certifi==2026.1.4
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via requests
-click==8.1.8
+click==8.3.1
     # via edx-django-utils
-coverage[toml]==7.8.0
+coverage[toml]==7.13.4
     # via pytest-cov
-cryptography==44.0.2
-    # via pyjwt
+cryptography==46.0.5
+    # via
+    #   google-auth
+    #   pyjwt
 ddt==1.7.2
     # via -r requirements/test.in
     # via
@@ -39,137 +42,139 @@ ddt==1.7.2
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-push-notifications==3.2.1
+django-push-notifications==3.3.0
     # via -r requirements/base.in
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via edx-django-utils
-edx-django-utils==7.4.0
+edx-django-utils==8.0.1
     # via -r requirements/base.in
-firebase-admin==6.8.0
+firebase-admin==7.1.0
     # via -r requirements/base.in
-google-api-core[grpc]==2.24.2
+google-api-core[grpc]==2.29.0
     # via
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.168.0
-    # via firebase-admin
-google-auth==2.39.0
+google-auth==2.48.0
     # via
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via google-api-python-client
-google-cloud-core==2.4.3
+google-cloud-core==2.5.0
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.20.2
+google-cloud-firestore==2.23.0
     # via firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.9.0
     # via firebase-admin
-google-crc32c==1.7.1
+google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.2
+google-resumable-media==2.8.0
     # via google-cloud-storage
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.72.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.72.0
+grpcio==1.78.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.0
+grpcio-status==1.78.0
     # via google-api-core
-httplib2==0.22.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
-hypothesis[pytz]==6.104.2
+h11==0.16.0
+    # via httpcore
+h2==4.3.0
+    # via httpx
+hpack==4.1.0
+    # via h2
+httpcore==1.0.9
+    # via httpx
+httpx[http2]==0.28.1
+    # via firebase-admin
+hyperframe==6.1.0
+    # via h2
+hypothesis[pytz]==6.151.6
     # via
     #   -r requirements/test.in
     #   hypothesis-pytest
 hypothesis-pytest==0.19.0
     # via -r requirements/test.in
-idna==3.10
-    # via requests
-iniconfig==2.1.0
+idna==3.11
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+iniconfig==2.3.0
     # via pytest
 jedi==0.19.2
     # via pudb
 mock==5.2.0
     # via -r requirements/test.in
-msgpack==1.1.0
+msgpack==1.1.2
     # via cachecontrol
-newrelic==10.10.0
-    # via edx-django-utils
-packaging==25.0
+packaging==26.0
     # via
     #   pudb
     #   pytest
-parso==0.8.4
+parso==0.8.6
     # via jedi
-pbr==6.1.1
-    # via stevedore
-pluggy==1.5.0
-    # via pytest
-proto-plus==1.26.1
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+proto-plus==1.27.1
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.30.2
+protobuf==6.33.5
     # via
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.0.0
+psutil==7.2.2
     # via edx-django-utils
-pudb==2024.1.3
+pudb==2025.1.5
     # via -r requirements/test.in
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==2.22
+pycparser==3.0
     # via cffi
-pygments==2.19.1
-    # via pudb
-pyjwt[crypto]==2.10.1
+pygments==2.19.2
+    # via
+    #   pudb
+    #   pytest
+pyjwt[crypto]==2.11.0
     # via firebase-admin
-pynacl==1.5.0
+pynacl==1.6.2
     # via edx-django-utils
-pyparsing==3.2.3
-    # via httplib2
-pytest==8.3.5
+pytest==9.0.2
     # via
     #   hypothesis-pytest
     #   pytest-cov
     #   pytest-django
     #   pytest-randomly
-pytest-cov==6.1.1
+pytest-cov==7.0.0
     # via -r requirements/test.in
 pytest-django==4.11.1
     # via -r requirements/test.in
-pytest-randomly==3.16.0
+pytest-randomly==4.0.1
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via -r requirements/base.in
 pytz==2025.2
     # via hypothesis
-requests==2.32.3
+requests==2.32.5
     # via
     #   cachecontrol
     #   google-api-core
@@ -179,7 +184,7 @@ rsa==4.9.1
     # via google-auth
 sailthru-client==2.2.3
     # via -r requirements/base.in
-simplejson==3.20.1
+simplejson==3.20.2
     # via sailthru-client
 six==1.17.0
     # via
@@ -187,28 +192,24 @@ six==1.17.0
     #   python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
-typing-extensions==4.13.2
-    # via urwid
-uritemplate==4.1.1
-    # via google-api-python-client
-urllib3==2.2.3
+typing-extensions==4.15.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   requests
-urwid==2.6.16
+    #   anyio
+    #   grpcio
+    #   pudb
+urllib3==2.6.3
+    # via requests
+urwid==3.0.5
     # via
     #   pudb
     #   urwid-readline
 urwid-readline==0.15.1
     # via pudb
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via urwid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -98,12 +98,10 @@ httpx[http2]==0.28.1
     # via firebase-admin
 hyperframe==6.1.0
     # via h2
-hypothesis[pytz]==6.151.6
+hypothesis[pytz]==6.90.0
     # via
     #   -r requirements/test.in
     #   hypothesis-pytest
-hypothesis-pytest==0.19.0
-    # via -r requirements/test.in
 idna==3.11
     # via
     #   anyio
@@ -168,7 +166,7 @@ pytest-cov==7.0.0
     # via -r requirements/test.in
 pytest-django==4.11.1
     # via -r requirements/test.in
-pytest-randomly==4.0.1
+pytest-randomly==3.15.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via -r requirements/base.in

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,12 @@
 [tox]
+minversion = 4.0
+isolated_build = true
 envlist = py{312}-django{42, 52}, docs, quality
 
 [testenv]
+skip_missing_interpreters = true
+setenv =
+    DJANGO_SETTINGS_MODULE = test_settings
 deps = 
     setuptools
     django42: Django>=4.2,<4.3


### PR DESCRIPTION

### Summary
Upgrade **Django from 4.2.20 to 4.2.25** in `edx-ace` to align with the latest
LTS patch release. This pulls in security and stability fixes while keeping us
compatible with the broader Open edX ecosystem
